### PR TITLE
Initialize ToneForge project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Flutter
+build/
+.ios/
+.android/
+flutter/
+pubspec.lock
+
+# Python
+__pycache__/
+*.py[cod]
+venv/
+
+# C++ build
+*.o
+*.a
+*.so
+build/
+
+# General
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# tonefordge
+# ToneForge
+
+ToneForge is an AI-powered guitar tone recreator that captures the sound of
+iconic recordings and rebuilds them for any guitarist. This repository hosts the
+initial skeleton for the application, including a Flutter frontend, a C++ audio
+engine, and a Python backend placeholder.
+
+## Project Structure
+
+- `frontend/` – Flutter application
+- `audio_engine/` – C++ digital signal processing core
+- `backend/` – Python backend and unit tests
+
+Each subdirectory contains its own README with additional details.
+
+## Getting Started
+
+1. Explore the subdirectories to see the current scaffolding.
+2. Run tests with `pytest`:
+
+   ```bash
+   pytest
+   ```
+
+More features and documentation will be added as the project evolves.

--- a/audio_engine/CMakeLists.txt
+++ b/audio_engine/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.10)
+project(audio_engine)
+
+add_library(audio_engine src/audio_engine.cpp)
+target_include_directories(audio_engine PUBLIC include)

--- a/audio_engine/README.md
+++ b/audio_engine/README.md
@@ -1,0 +1,5 @@
+# Audio Engine
+
+C++ placeholder for the ToneForge digital signal processing core. The library
+currently exposes a simple `process` function that prints a placeholder
+message. This will evolve into the core DSP engine.

--- a/audio_engine/include/audio_engine.h
+++ b/audio_engine/include/audio_engine.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace toneforge {
+  // Placeholder audio engine function
+  void process();
+}

--- a/audio_engine/src/audio_engine.cpp
+++ b/audio_engine/src/audio_engine.cpp
@@ -1,0 +1,8 @@
+#include "audio_engine.h"
+#include <iostream>
+
+namespace toneforge {
+  void process() {
+    std::cout << "Audio processing placeholder" << std::endl;
+  }
+}

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,5 @@
+# ToneForge Backend
+
+Placeholder backend implementation. Currently includes a stub `analyze_tone`
+function and accompanying unit test. This will evolve into a full API for
+song analysis and tone reconstruction.

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package for ToneForge."""

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,15 @@
+"""ToneForge backend skeleton.
+
+This module currently contains a placeholder function for tone analysis.
+"""
+
+def analyze_tone(song_url: str) -> dict:
+    """Return a placeholder tone profile for the given song URL.
+
+    Args:
+        song_url: URL or identifier of the song to analyze.
+
+    Returns:
+        A dictionary with the original URL and a placeholder tone string.
+    """
+    return {"song_url": song_url, "tone": "placeholder"}

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -1,0 +1,8 @@
+from backend.app import analyze_tone
+
+
+def test_analyze_tone_returns_placeholder():
+    url = "https://example.com/song"
+    result = analyze_tone(url)
+    assert result["song_url"] == url
+    assert result["tone"] == "placeholder"

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,5 @@
+# ToneForge Frontend
+
+This directory contains the Flutter application for ToneForge. It currently
+provides a minimal `main.dart` entry point that will expand as the project
+develops.

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const ToneForgeApp());
+}
+
+class ToneForgeApp extends StatelessWidget {
+  const ToneForgeApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'ToneForge',
+      home: Scaffold(
+        appBar: AppBar(title: const Text('ToneForge')),
+        body: const Center(child: Text('Welcome to ToneForge')),
+      ),
+    );
+  }
+}

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -1,0 +1,13 @@
+name: toneforge
+description: A starting point for the ToneForge Flutter app.
+version: 0.1.0
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+dependencies:
+  flutter:
+    sdk: flutter
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- scaffold Flutter frontend with basic `main.dart`
- add C++ audio_engine library skeleton using CMake
- introduce Python backend placeholder with unit test

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5c0ead8708331baa16147ada0ca73