### PR TITLE
Add tone summary helper to backend

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,5 +1,6 @@
 # ToneForge Backend
 
 Placeholder backend implementation. Currently includes a stub `analyze_tone`
-function and accompanying unit test. This will evolve into a full API for
-song analysis and tone reconstruction.
+function, a `summarize_tone` helper for formatting results, and corresponding
+unit tests. This will evolve into a full API for song analysis and tone
+reconstruction.

--- a/backend/app.py
+++ b/backend/app.py
@@ -13,3 +13,19 @@ def analyze_tone(song_url: str) -> dict:
         A dictionary with the original URL and a placeholder tone string.
     """
     return {"song_url": song_url, "tone": "placeholder"}
+
+
+def summarize_tone(profile: dict) -> str:
+    """Create a human-readable summary from a tone profile.
+
+    Args:
+        profile: A dictionary containing tone information, typically the
+            result of :func:`analyze_tone`.
+
+    Returns:
+        A string summarizing the song URL and its tone description.
+    """
+
+    song_url = profile.get("song_url", "unknown song")
+    tone = profile.get("tone", "unknown tone")
+    return f"Tone profile for {song_url}: {tone}"

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -1,4 +1,8 @@
-from backend.app import analyze_tone
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+from backend.app import analyze_tone, summarize_tone
 
 
 def test_analyze_tone_returns_placeholder():
@@ -6,3 +10,9 @@ def test_analyze_tone_returns_placeholder():
     result = analyze_tone(url)
     assert result["song_url"] == url
     assert result["tone"] == "placeholder"
+
+
+def test_summarize_tone_formats_output():
+    profile = {"song_url": "https://example.com/song", "tone": "warm"}
+    summary = summarize_tone(profile)
+    assert summary == "Tone profile for https://example.com/song: warm"


### PR DESCRIPTION
## Summary
- add `summarize_tone` helper to format tone analysis results
- test summary formatting alongside existing analysis stub
- document new helper in backend README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5c800b3648331a157be70452df56f